### PR TITLE
Calling to available archive extractors, instead of implementing our own

### DIFF
--- a/compression-plugin-common/pom.xml
+++ b/compression-plugin-common/pom.xml
@@ -35,6 +35,14 @@
       <version>2024.07</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.teamcity.internal</groupId>
+      <artifactId>server</artifactId>
+      <version>${teamcity-version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>

--- a/compression-plugin-common/src/test/java/net/quasardb/teamcity/compression/tests/impl/ZstdTestArchiveExtractor.java
+++ b/compression-plugin-common/src/test/java/net/quasardb/teamcity/compression/tests/impl/ZstdTestArchiveExtractor.java
@@ -1,7 +1,22 @@
 package net.quasardb.teamcity.compression.tests.impl;
 
 import jetbrains.buildServer.ExtensionHolder;
+import jetbrains.buildServer.util.ArchiveExtractor;
+import jetbrains.buildServer.util.impl.TarArchiveExtractor;
+import jetbrains.buildServer.util.impl.ZipArchiveExtractor;
 import net.quasardb.teamcity.compression.ZstdExtractor;
+import net.quasardb.teamcity.compression.logging.Logger;
+import net.quasardb.teamcity.compression.utils.ZstdCompressionUtils;
+import org.apache.commons.compress.archivers.ArchiveStreamFactory;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
 
 public class ZstdTestArchiveExtractor implements ZstdExtractor {
 
@@ -12,4 +27,21 @@ public class ZstdTestArchiveExtractor implements ZstdExtractor {
         return null;
     }
 
+    @Override
+    public ArchiveExtractor getArchiveType(@NotNull File archive) {
+        Logger.debug("Call isSupportedArchiveType for " + archive.getName());
+        try {
+            try (InputStream inputStream = new BufferedInputStream(Files.newInputStream(archive.toPath()))) {
+                if(ZstdCompressionUtils.isArchiveOfType(inputStream, Collections.singletonList(ArchiveStreamFactory.TAR))){
+                    return new TarArchiveExtractor();
+                }
+                if(ZstdCompressionUtils.isArchiveOfType(inputStream, Collections.singletonList(ArchiveStreamFactory.ZIP))){
+                    return new ZipArchiveExtractor();
+                }
+            }
+        } catch (IOException e) {
+            Logger.error("Caught exception during test of archive", e);
+        }
+        return null;
+    }
 }

--- a/compression-plugin-server/pom.xml
+++ b/compression-plugin-server/pom.xml
@@ -45,12 +45,7 @@
       <scope>provided</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.jetbrains.teamcity.internal</groupId>
-      <artifactId>server</artifactId>
-      <version>${teamcity-version}</version>
-      <scope>provided</scope>
-    </dependency>
+
 
     <dependency>
       <groupId>org.jetbrains.teamcity.internal</groupId>


### PR DESCRIPTION
With implementing our extractors we in some cases lost execution bit on files, as well as file permissions can get messy.
Now calling available extractors.